### PR TITLE
Add activities section and list view toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import CattleList from './components/cattle/CattleList';
 import PastureList from './components/pastures/PastureList';
 import FeedingList from './components/feeding/FeedingList';
 import HealthList from './components/health/HealthList';
+import ActivityList from './components/activities/ActivityList';
 
 function App() {
   const [currentView, setCurrentView] = React.useState('dashboard');
@@ -18,6 +19,7 @@ function App() {
         {currentView === 'pastures' && <PastureList />}
         {currentView === 'feeding' && <FeedingList />}
         {currentView === 'health' && <HealthList />}
+        {currentView === 'activities' && <ActivityList />}
       </main>
     </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, LayoutDashboard, Users, Map, Wheat, Activity, Settings } from 'lucide-react';
+import { Menu, LayoutDashboard, Users, Map, Wheat, Activity, Settings, ListTodo } from 'lucide-react';
 
 interface NavbarProps {
   onNavigate: (view: string) => void;
@@ -15,6 +15,7 @@ export default function Navbar({ onNavigate, currentView }: NavbarProps) {
     { icon: Map, label: 'Parcelas', id: 'pastures' },
     { icon: Wheat, label: 'Alimentación', id: 'feeding' },
     { icon: Activity, label: 'Salud', id: 'health' },
+    { icon: ListTodo, label: 'Actividades', id: 'activities' },
     { icon: Settings, label: 'Configuración', id: 'settings' },
   ];
 

--- a/src/components/activities/ActivityCard.tsx
+++ b/src/components/activities/ActivityCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CalendarDays } from 'lucide-react';
+import type { Activity } from '../../types';
+
+interface ActivityCardProps {
+  activity: Activity;
+}
+
+const typeColors: Record<string, string> = {
+  feeding: 'bg-green-100 text-green-800',
+  weighing: 'bg-blue-100 text-blue-800',
+  rotation: 'bg-purple-100 text-purple-800',
+};
+
+export default function ActivityCard({ activity }: ActivityCardProps) {
+  const color = typeColors[activity.type] || 'bg-gray-100 text-gray-800';
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+      <div className="flex justify-between items-start mb-4">
+        <h3 className="text-lg font-semibold">{activity.title}</h3>
+        <span className={`px-2 py-1 rounded-full text-sm ${color}`}>{activity.type}</span>
+      </div>
+      <div className="flex items-center text-gray-600">
+        <CalendarDays className="w-4 h-4 mr-2" />
+        <span className="text-sm">{activity.date}</span>
+      </div>
+      <div className="mt-4 pt-4 border-t flex justify-end space-x-2">
+        <button className="btn btn-secondary text-sm">Ver</button>
+        <button className="btn btn-primary text-sm">Editar</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/activities/ActivityList.tsx
+++ b/src/components/activities/ActivityList.tsx
@@ -1,56 +1,32 @@
 import React from 'react';
 import { Search, Plus } from 'lucide-react';
-import type { Pasture } from '../../types';
-import PastureCard from './PastureCard';
+import type { Activity } from '../../types';
+import ActivityCard from './ActivityCard';
 import ViewToggle from '../ViewToggle';
 
-const MOCK_PASTURES: Pasture[] = [
-  {
-    id: '1',
-    name: 'Parcela Norte',
-    area: 5.5,
-    status: 'active',
-    last_rotation: '2024-03-01',
-    grass_type: 'Brachiaria',
-    capacity: 25
-  },
-  {
-    id: '2',
-    name: 'Parcela Este',
-    area: 4.2,
-    status: 'resting',
-    last_rotation: '2024-02-15',
-    grass_type: 'Pangola',
-    capacity: 20
-  },
-  {
-    id: '3',
-    name: 'Parcela Sur',
-    area: 6.0,
-    status: 'maintenance',
-    last_rotation: '2024-03-10',
-    grass_type: 'Estrella',
-    capacity: 30
-  }
+const MOCK_ACTIVITIES: Activity[] = [
+  { id: '1', title: 'Alimentación mañana', date: '2024-03-25', type: 'feeding' },
+  { id: '2', title: 'Rotación Parcela 4', date: '2024-03-26', type: 'rotation' },
+  { id: '3', title: 'Pesaje mensual', date: '2024-03-28', type: 'weighing' },
 ];
 
-export default function PastureList() {
+export default function ActivityList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [view, setView] = React.useState<'grid' | 'list'>('grid');
 
-  const filteredPastures = MOCK_PASTURES.filter(pasture =>
-    pasture.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredActivities = MOCK_ACTIVITIES.filter((activity) =>
+    activity.title.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">Gestión de Parcelas</h1>
+        <h1 className="text-2xl font-bold">Programación de Actividades</h1>
         <div className="flex gap-4">
           <ViewToggle view={view} onViewChange={setView} />
           <button className="btn btn-primary flex items-center">
             <Plus className="w-4 h-4 mr-2" />
-            Nueva Parcela
+            Nueva Actividad
           </button>
         </div>
       </div>
@@ -60,7 +36,7 @@ export default function PastureList() {
           <Search className="absolute left-3 top-2.5 h-5 w-5 text-gray-400" />
           <input
             type="text"
-            placeholder="Buscar parcela..."
+            placeholder="Buscar actividad..."
             className="input pl-10"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
@@ -70,8 +46,8 @@ export default function PastureList() {
 
       {view === 'grid' ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredPastures.map((pasture) => (
-            <PastureCard key={pasture.id} pasture={pasture} />
+          {filteredActivities.map((activity) => (
+            <ActivityCard key={activity.id} activity={activity} />
           ))}
         </div>
       ) : (
@@ -80,16 +56,13 @@ export default function PastureList() {
             <thead className="bg-gray-50">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Nombre
+                  Actividad
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Estado
+                  Fecha
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Área
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Capacidad
+                  Tipo
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Acciones
@@ -97,12 +70,11 @@ export default function PastureList() {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {filteredPastures.map((pasture) => (
-                <tr key={pasture.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4">{pasture.name}</td>
-                  <td className="px-6 py-4">{pasture.status}</td>
-                  <td className="px-6 py-4">{pasture.area} ha</td>
-                  <td className="px-6 py-4">{pasture.capacity}</td>
+              {filteredActivities.map((activity) => (
+                <tr key={activity.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4">{activity.title}</td>
+                  <td className="px-6 py-4">{activity.date}</td>
+                  <td className="px-6 py-4">{activity.type}</td>
                   <td className="px-6 py-4 text-sm text-gray-500">
                     <div className="flex space-x-2">
                       <button className="text-blue-600 hover:text-blue-900">Ver</button>
@@ -116,9 +88,9 @@ export default function PastureList() {
         </div>
       )}
 
-      {filteredPastures.length === 0 && (
+      {filteredActivities.length === 0 && (
         <div className="text-center py-12">
-          <p className="text-gray-500">No se encontraron parcelas.</p>
+          <p className="text-gray-500">No se encontraron actividades programadas.</p>
         </div>
       )}
     </div>

--- a/src/components/feeding/FeedingList.tsx
+++ b/src/components/feeding/FeedingList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Search, Plus, Calendar } from 'lucide-react';
 import type { FeedingRecord } from '../../types';
 import FeedingCard from './FeedingCard';
+import ViewToggle from '../ViewToggle';
 
 const MOCK_FEEDING: FeedingRecord[] = [
   {
@@ -27,6 +28,7 @@ const MOCK_FEEDING: FeedingRecord[] = [
 export default function FeedingList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [selectedDate, setSelectedDate] = React.useState('');
+  const [view, setView] = React.useState<'grid' | 'list'>('grid');
 
   const filteredRecords = MOCK_FEEDING.filter(record => {
     const matchesSearch = record.feed_type.toLowerCase().includes(searchTerm.toLowerCase());
@@ -38,10 +40,13 @@ export default function FeedingList() {
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Registro de Alimentación</h1>
-        <button className="btn btn-primary flex items-center">
-          <Plus className="w-4 h-4 mr-2" />
-          Nuevo Registro
-        </button>
+        <div className="flex gap-4">
+          <ViewToggle view={view} onViewChange={setView} />
+          <button className="btn btn-primary flex items-center">
+            <Plus className="w-4 h-4 mr-2" />
+            Nuevo Registro
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col md:flex-row gap-4 mb-6">
@@ -67,11 +72,43 @@ export default function FeedingList() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {filteredRecords.map((record) => (
-          <FeedingCard key={record.id} record={record} />
-        ))}
-      </div>
+      {view === 'grid' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredRecords.map((record) => (
+            <FeedingCard key={record.id} record={record} />
+          ))}
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-md overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Parcela</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cantidad</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredRecords.map((record) => (
+                <tr key={record.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4">{record.pasture_id}</td>
+                  <td className="px-6 py-4">{record.date}</td>
+                  <td className="px-6 py-4">{record.feed_type}</td>
+                  <td className="px-6 py-4">{record.quantity} kg</td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    <div className="flex space-x-2">
+                      <button className="text-blue-600 hover:text-blue-900">Ver</button>
+                      <button className="text-green-600 hover:text-green-900">Editar</button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {filteredRecords.length === 0 && (
         <div className="text-center py-12">

--- a/src/components/health/HealthList.tsx
+++ b/src/components/health/HealthList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Search, Plus, Calendar } from 'lucide-react';
 import type { HealthRecord } from '../../types';
 import HealthCard from './HealthCard';
+import ViewToggle from '../ViewToggle';
 
 const MOCK_HEALTH: HealthRecord[] = [
   {
@@ -25,6 +26,7 @@ const MOCK_HEALTH: HealthRecord[] = [
 export default function HealthList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [selectedDate, setSelectedDate] = React.useState('');
+  const [view, setView] = React.useState<'grid' | 'list'>('grid');
 
   const filteredRecords = MOCK_HEALTH.filter(record => {
     const matchesSearch = record.cattle_id.toLowerCase().includes(searchTerm.toLowerCase());
@@ -36,10 +38,13 @@ export default function HealthList() {
     <div className="p-6">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Registro de Salud</h1>
-        <button className="btn btn-primary flex items-center">
-          <Plus className="w-4 h-4 mr-2" />
-          Nuevo Registro
-        </button>
+        <div className="flex gap-4">
+          <ViewToggle view={view} onViewChange={setView} />
+          <button className="btn btn-primary flex items-center">
+            <Plus className="w-4 h-4 mr-2" />
+            Nuevo Registro
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col md:flex-row gap-4 mb-6">
@@ -65,11 +70,41 @@ export default function HealthList() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {filteredRecords.map((record) => (
-          <HealthCard key={record.id} record={record} />
-        ))}
-      </div>
+      {view === 'grid' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredRecords.map((record) => (
+            <HealthCard key={record.id} record={record} />
+          ))}
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-md overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Animal</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredRecords.map((record) => (
+                <tr key={record.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4">{record.cattle_id}</td>
+                  <td className="px-6 py-4">{record.date}</td>
+                  <td className="px-6 py-4">{record.type}</td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    <div className="flex space-x-2">
+                      <button className="text-blue-600 hover:text-blue-900">Ver</button>
+                      <button className="text-green-600 hover:text-green-900">Editar</button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {filteredRecords.length === 0 && (
         <div className="text-center py-12">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,3 +46,10 @@ export interface HealthRecord {
   description: string;
   performed_by: string;
 }
+
+export interface Activity {
+  id: string;
+  title: string;
+  date: string;
+  type: string;
+}


### PR DESCRIPTION
## Summary
- add Activities navigation option and view component
- support grid or list view for pastures, feeding and health sections
- expose Activity type in shared types
- show Activities in App navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852df68c6a88332ab4c3622395e4183