### PR TITLE
Persist view preference

### DIFF
--- a/src/components/activities/ActivityList.tsx
+++ b/src/components/activities/ActivityList.tsx
@@ -4,6 +4,7 @@ import type { Activity } from '../../types';
 import ActivityCard from './ActivityCard';
 import ViewToggle from '../ViewToggle';
 import ActivityForm from './forms/ActivityForm';
+import usePersistedView from '../../hooks/usePersistedView';
 
 const MOCK_ACTIVITIES: Activity[] = [
   { id: '1', title: 'Alimentación mañana', date: '2024-03-25', type: 'feeding' },
@@ -13,7 +14,7 @@ const MOCK_ACTIVITIES: Activity[] = [
 
 export default function ActivityList() {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const [view, setView] = React.useState<'grid' | 'list'>('grid');
+  const [view, setView] = usePersistedView('activities-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Activity | undefined>();
   const [readOnly, setReadOnly] = React.useState(false);

--- a/src/components/cattle/CattleList.tsx
+++ b/src/components/cattle/CattleList.tsx
@@ -4,6 +4,7 @@ import type { Animal } from '../../types';
 import CattleCard from './CattleCard'; // reutilizamos el diseño para cualquier animal
 import { getDocList } from '../../api/erpnext';
 import ViewToggle from '../ViewToggle';
+import usePersistedView from '../../hooks/usePersistedView';
 import CattleForm from './forms/CattleForm';
 
 const MOCK_CATTLE: Animal[] = [
@@ -49,7 +50,7 @@ const statusLabels = {
 export default function CattleList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [statusFilter, setStatusFilter] = React.useState<Animal['status'] | 'all'>('all');
-  const [view, setView] = React.useState<'grid' | 'list'>('grid');
+  const [view, setView] = usePersistedView('cattle-view', 'grid');
   const [animals, setAnimals] = React.useState<Animal[]>(MOCK_CATTLE);
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Animal | undefined>();

--- a/src/components/feeding/FeedingList.tsx
+++ b/src/components/feeding/FeedingList.tsx
@@ -4,6 +4,7 @@ import type { FeedingRecord } from '../../types';
 import FeedingCard from './FeedingCard';
 import ViewToggle from '../ViewToggle';
 import FeedingForm from './forms/FeedingForm';
+import usePersistedView from '../../hooks/usePersistedView';
 
 const MOCK_FEEDING: FeedingRecord[] = [
   {
@@ -29,7 +30,7 @@ const MOCK_FEEDING: FeedingRecord[] = [
 export default function FeedingList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [selectedDate, setSelectedDate] = React.useState('');
-  const [view, setView] = React.useState<'grid' | 'list'>('grid');
+  const [view, setView] = usePersistedView('feeding-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<FeedingRecord | undefined>();
   const [readOnly, setReadOnly] = React.useState(false);

--- a/src/components/health/HealthList.tsx
+++ b/src/components/health/HealthList.tsx
@@ -4,6 +4,7 @@ import type { HealthRecord } from '../../types';
 import HealthCard from './HealthCard';
 import ViewToggle from '../ViewToggle';
 import HealthForm from './forms/HealthForm';
+import usePersistedView from '../../hooks/usePersistedView';
 
 const MOCK_HEALTH: HealthRecord[] = [
   {
@@ -27,7 +28,7 @@ const MOCK_HEALTH: HealthRecord[] = [
 export default function HealthList() {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [selectedDate, setSelectedDate] = React.useState('');
-  const [view, setView] = React.useState<'grid' | 'list'>('grid');
+  const [view, setView] = usePersistedView('health-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<HealthRecord | undefined>();
   const [readOnly, setReadOnly] = React.useState(false);

--- a/src/components/pastures/PastureList.tsx
+++ b/src/components/pastures/PastureList.tsx
@@ -4,6 +4,7 @@ import type { Pasture } from '../../types';
 import PastureCard from './PastureCard';
 import ViewToggle from '../ViewToggle';
 import PastureForm from './forms/PastureForm';
+import usePersistedView from '../../hooks/usePersistedView';
 
 const MOCK_PASTURES: Pasture[] = [
   {
@@ -37,7 +38,7 @@ const MOCK_PASTURES: Pasture[] = [
 
 export default function PastureList() {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const [view, setView] = React.useState<'grid' | 'list'>('grid');
+  const [view, setView] = usePersistedView('pastures-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Pasture | undefined>();
   const [readOnly, setReadOnly] = React.useState(false);

--- a/src/hooks/usePersistedView.ts
+++ b/src/hooks/usePersistedView.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function usePersistedView(key: string, initial: 'grid' | 'list' = 'grid') {
+  const [view, setView] = React.useState<'grid' | 'list'>(() => {
+    if (typeof window === 'undefined') return initial;
+    const stored = localStorage.getItem(key);
+    return stored === 'grid' || stored === 'list' ? (stored as 'grid' | 'list') : initial;
+  });
+
+  const setPersistedView = React.useCallback(
+    (next: 'grid' | 'list') => {
+      setView(next);
+      try {
+        localStorage.setItem(key, next);
+      } catch {
+        // ignore
+      }
+    },
+    [key]
+  );
+
+  return [view, setPersistedView] as const;
+}


### PR DESCRIPTION
## Summary
- remember list/grid option across visits using `usePersistedView`
- apply the new hook to activity, cattle, feeding, health and pasture lists
