### PR TITLE
Implement date range filtering

### DIFF
--- a/src/components/activities/ActivityList.tsx
+++ b/src/components/activities/ActivityList.tsx
@@ -14,7 +14,8 @@ const MOCK_ACTIVITIES: Activity[] = [
 
 export default function ActivityList() {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const [selectedDate, setSelectedDate] = React.useState('');
+  const [fromDate, setFromDate] = React.useState('');
+  const [toDate, setToDate] = React.useState('');
   const [view, setView] = usePersistedView('activities-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Activity | undefined>();
@@ -25,7 +26,9 @@ export default function ActivityList() {
     const matchesSearch = activity.title
       .toLowerCase()
       .includes(searchTerm.toLowerCase());
-    const matchesDate = !selectedDate || activity.date === selectedDate;
+    const matchesFrom = !fromDate || activity.date >= fromDate;
+    const matchesTo = !toDate || activity.date <= toDate;
+    const matchesDate = matchesFrom && matchesTo;
     return matchesSearch && matchesDate;
   });
 
@@ -66,8 +69,15 @@ export default function ActivityList() {
           <input
             type="date"
             className="input !w-auto"
-            value={selectedDate}
-            onChange={(e) => setSelectedDate(e.target.value)}
+            value={fromDate}
+            onChange={(e) => setFromDate(e.target.value)}
+          />
+          <span className="mx-1">-</span>
+          <input
+            type="date"
+            className="input !w-auto"
+            value={toDate}
+            onChange={(e) => setToDate(e.target.value)}
           />
         </div>
       </div>

--- a/src/components/feeding/FeedingList.tsx
+++ b/src/components/feeding/FeedingList.tsx
@@ -29,7 +29,8 @@ const MOCK_FEEDING: FeedingRecord[] = [
 
 export default function FeedingList() {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const [selectedDate, setSelectedDate] = React.useState('');
+  const [fromDate, setFromDate] = React.useState('');
+  const [toDate, setToDate] = React.useState('');
   const [view, setView] = usePersistedView('feeding-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<FeedingRecord | undefined>();
@@ -38,7 +39,9 @@ export default function FeedingList() {
 
   const filteredRecords = records.filter(record => {
     const matchesSearch = record.feed_type.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesDate = !selectedDate || record.date === selectedDate;
+    const matchesFrom = !fromDate || record.date >= fromDate;
+    const matchesTo = !toDate || record.date <= toDate;
+    const matchesDate = matchesFrom && matchesTo;
     return matchesSearch && matchesDate;
   });
 
@@ -79,8 +82,15 @@ export default function FeedingList() {
           <input
             type="date"
             className="input !w-auto"
-            value={selectedDate}
-            onChange={(e) => setSelectedDate(e.target.value)}
+            value={fromDate}
+            onChange={(e) => setFromDate(e.target.value)}
+          />
+          <span className="mx-1">-</span>
+          <input
+            type="date"
+            className="input !w-auto"
+            value={toDate}
+            onChange={(e) => setToDate(e.target.value)}
           />
         </div>
       </div>

--- a/src/components/health/HealthList.tsx
+++ b/src/components/health/HealthList.tsx
@@ -27,7 +27,8 @@ const MOCK_HEALTH: HealthRecord[] = [
 
 export default function HealthList() {
   const [searchTerm, setSearchTerm] = React.useState('');
-  const [selectedDate, setSelectedDate] = React.useState('');
+  const [fromDate, setFromDate] = React.useState('');
+  const [toDate, setToDate] = React.useState('');
   const [view, setView] = usePersistedView('health-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<HealthRecord | undefined>();
@@ -36,7 +37,9 @@ export default function HealthList() {
 
   const filteredRecords = records.filter(record => {
     const matchesSearch = record.cattle_id.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesDate = !selectedDate || record.date === selectedDate;
+    const matchesFrom = !fromDate || record.date >= fromDate;
+    const matchesTo = !toDate || record.date <= toDate;
+    const matchesDate = matchesFrom && matchesTo;
     return matchesSearch && matchesDate;
   });
 
@@ -77,8 +80,15 @@ export default function HealthList() {
           <input
             type="date"
             className="input !w-auto"
-            value={selectedDate}
-            onChange={(e) => setSelectedDate(e.target.value)}
+            value={fromDate}
+            onChange={(e) => setFromDate(e.target.value)}
+          />
+          <span className="mx-1">-</span>
+          <input
+            type="date"
+            className="input !w-auto"
+            value={toDate}
+            onChange={(e) => setToDate(e.target.value)}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add start/end date filters for activities
- add start/end date filters for feeding records
- add start/end date filters for health records

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f5f4b3e88332bb83a7cac5de72fe