### PR TITLE
Add persistent filters with clear options

### DIFF
--- a/src/components/activities/ActivityList.tsx
+++ b/src/components/activities/ActivityList.tsx
@@ -5,6 +5,7 @@ import ActivityCard from './ActivityCard';
 import ViewToggle from '../ViewToggle';
 import ActivityForm from './forms/ActivityForm';
 import usePersistedView from '../../hooks/usePersistedView';
+import usePersistedState from '../../hooks/usePersistedState';
 
 const MOCK_ACTIVITIES: Activity[] = [
   { id: '1', title: 'Alimentación mañana', date: '2024-03-25', type: 'feeding' },
@@ -13,9 +14,9 @@ const MOCK_ACTIVITIES: Activity[] = [
 ];
 
 export default function ActivityList() {
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [fromDate, setFromDate] = React.useState('');
-  const [toDate, setToDate] = React.useState('');
+  const [searchTerm, setSearchTerm] = usePersistedState('activity-search', '');
+  const [fromDate, setFromDate] = usePersistedState('activity-from', '');
+  const [toDate, setToDate] = usePersistedState('activity-to', '');
   const [view, setView] = usePersistedView('activities-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Activity | undefined>();
@@ -80,6 +81,16 @@ export default function ActivityList() {
             onChange={(e) => setToDate(e.target.value)}
           />
         </div>
+        <button
+          className="btn btn-secondary self-start md:ml-auto"
+          onClick={() => {
+            setSearchTerm('');
+            setFromDate('');
+            setToDate('');
+          }}
+        >
+          Borrar filtros
+        </button>
       </div>
 
       {view === 'grid' ? (

--- a/src/components/cattle/CattleList.tsx
+++ b/src/components/cattle/CattleList.tsx
@@ -5,6 +5,7 @@ import CattleCard from './CattleCard'; // reutilizamos el diseño para cualquier
 import { getDocList } from '../../api/erpnext';
 import ViewToggle from '../ViewToggle';
 import usePersistedView from '../../hooks/usePersistedView';
+import usePersistedState from '../../hooks/usePersistedState';
 import CattleForm from './forms/CattleForm';
 
 const MOCK_CATTLE: Animal[] = [
@@ -48,8 +49,8 @@ const statusLabels = {
 };
 
 export default function CattleList() {
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [statusFilter, setStatusFilter] = React.useState<Animal['status'] | 'all'>('all');
+  const [searchTerm, setSearchTerm] = usePersistedState('cattle-search', '');
+  const [statusFilter, setStatusFilter] = usePersistedState<Animal['status'] | 'all'>('cattle-status', 'all');
   const [view, setView] = usePersistedView('cattle-view', 'grid');
   const [animals, setAnimals] = React.useState<Animal[]>(MOCK_CATTLE);
   const [showForm, setShowForm] = React.useState(false);
@@ -115,6 +116,15 @@ export default function CattleList() {
             <option value="lactating">Lactando</option>
           </select>
         </div>
+        <button
+          className="btn btn-secondary self-start md:ml-auto"
+          onClick={() => {
+            setSearchTerm('');
+            setStatusFilter('all');
+          }}
+        >
+          Borrar filtros
+        </button>
       </div>
 
       {view === 'grid' ? (

--- a/src/components/feeding/FeedingList.tsx
+++ b/src/components/feeding/FeedingList.tsx
@@ -5,6 +5,7 @@ import FeedingCard from './FeedingCard';
 import ViewToggle from '../ViewToggle';
 import FeedingForm from './forms/FeedingForm';
 import usePersistedView from '../../hooks/usePersistedView';
+import usePersistedState from '../../hooks/usePersistedState';
 
 const MOCK_FEEDING: FeedingRecord[] = [
   {
@@ -28,9 +29,9 @@ const MOCK_FEEDING: FeedingRecord[] = [
 ];
 
 export default function FeedingList() {
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [fromDate, setFromDate] = React.useState('');
-  const [toDate, setToDate] = React.useState('');
+  const [searchTerm, setSearchTerm] = usePersistedState('feeding-search', '');
+  const [fromDate, setFromDate] = usePersistedState('feeding-from', '');
+  const [toDate, setToDate] = usePersistedState('feeding-to', '');
   const [view, setView] = usePersistedView('feeding-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<FeedingRecord | undefined>();
@@ -93,6 +94,16 @@ export default function FeedingList() {
             onChange={(e) => setToDate(e.target.value)}
           />
         </div>
+        <button
+          className="btn btn-secondary self-start md:ml-auto"
+          onClick={() => {
+            setSearchTerm('');
+            setFromDate('');
+            setToDate('');
+          }}
+        >
+          Borrar filtros
+        </button>
       </div>
 
       {view === 'grid' ? (

--- a/src/components/health/HealthList.tsx
+++ b/src/components/health/HealthList.tsx
@@ -5,6 +5,7 @@ import HealthCard from './HealthCard';
 import ViewToggle from '../ViewToggle';
 import HealthForm from './forms/HealthForm';
 import usePersistedView from '../../hooks/usePersistedView';
+import usePersistedState from '../../hooks/usePersistedState';
 
 const MOCK_HEALTH: HealthRecord[] = [
   {
@@ -26,9 +27,9 @@ const MOCK_HEALTH: HealthRecord[] = [
 ];
 
 export default function HealthList() {
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [fromDate, setFromDate] = React.useState('');
-  const [toDate, setToDate] = React.useState('');
+  const [searchTerm, setSearchTerm] = usePersistedState('health-search', '');
+  const [fromDate, setFromDate] = usePersistedState('health-from', '');
+  const [toDate, setToDate] = usePersistedState('health-to', '');
   const [view, setView] = usePersistedView('health-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<HealthRecord | undefined>();
@@ -91,6 +92,16 @@ export default function HealthList() {
             onChange={(e) => setToDate(e.target.value)}
           />
         </div>
+        <button
+          className="btn btn-secondary self-start md:ml-auto"
+          onClick={() => {
+            setSearchTerm('');
+            setFromDate('');
+            setToDate('');
+          }}
+        >
+          Borrar filtros
+        </button>
       </div>
 
       {view === 'grid' ? (

--- a/src/components/pastures/PastureList.tsx
+++ b/src/components/pastures/PastureList.tsx
@@ -5,6 +5,7 @@ import PastureCard from './PastureCard';
 import ViewToggle from '../ViewToggle';
 import PastureForm from './forms/PastureForm';
 import usePersistedView from '../../hooks/usePersistedView';
+import usePersistedState from '../../hooks/usePersistedState';
 
 const MOCK_PASTURES: Pasture[] = [
   {
@@ -37,7 +38,7 @@ const MOCK_PASTURES: Pasture[] = [
 ];
 
 export default function PastureList() {
-  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchTerm, setSearchTerm] = usePersistedState('pasture-search', '');
   const [view, setView] = usePersistedView('pastures-view', 'grid');
   const [showForm, setShowForm] = React.useState(false);
   const [selected, setSelected] = React.useState<Pasture | undefined>();
@@ -79,6 +80,12 @@ export default function PastureList() {
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </div>
+        <button
+          className="btn btn-secondary ml-2"
+          onClick={() => setSearchTerm('')}
+        >
+          Borrar filtros
+        </button>
       </div>
 
       {view === 'grid' ? (

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function usePersistedState<T>(key: string, initial: T) {
+  const [state, setState] = React.useState<T>(() => {
+    if (typeof window === 'undefined') return initial;
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  const setPersistedState = React.useCallback(
+    (next: React.SetStateAction<T>) => {
+      setState((prev) => {
+        const value = typeof next === 'function' ? (next as (v: T) => T)(prev) : next;
+        try {
+          localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+          // ignore
+        }
+        return value;
+      });
+    },
+    [key]
+  );
+
+  return [state, setPersistedState] as const;
+}


### PR DESCRIPTION
## Summary
- persist filter values across sessions using new `usePersistedState`
- add clear-filters button to each list component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f77bb74083329af5a2c095fd282a